### PR TITLE
45-style-change-colors-and-appareance-of-the-button-interes

### DIFF
--- a/src/features/EventsUsers/components/PublicEventDetail.jsx
+++ b/src/features/EventsUsers/components/PublicEventDetail.jsx
@@ -67,8 +67,8 @@ const PublicEventDetail = ({ evento, onVolver, onInteres, isInterested, onElimin
               disabled={isProcessing}
               className={`w-full sm:w-auto px-8 py-3.5 rounded-xl flex items-center justify-center font-bold text-base transition-all duration-300 shadow-sm ${
                 isInterested
-                ? 'bg-green-500 text-white hover:bg-green-600 active:scale-95'
-                : 'bg-red-500 text-white hover:bg-red-600 active:scale-95'
+                ? 'bg-gray-400 text-white hover:bg-gray-500 active:scale-95'
+                : 'bg-blue-500 text-white hover:bg-blue-600 active:scale-95'
                 }`}
             >
               {isProcessing ? (


### PR DESCRIPTION
Adjust button color classes in PublicEventDetail.jsx: when isInterested is true the button is now gray (bg-gray-400 / hover:bg-gray-500) instead of green, and when false it uses blue (bg-blue-500 / hover:bg-blue-600) instead of red. Active scaling and other layout classes were left unchanged. This likely reflects a design update to use a neutral state for already-interested events and a primary color for the call-to-action. #45 