### PR TITLE
52-feat-add-the-route-of-the-backend-in-the-actual-service-of-the-frontend-to-reportrank-the-events-grouped-by-their-popularity

### DIFF
--- a/src/features/EventsAdmin/services/reportService.js
+++ b/src/features/EventsAdmin/services/reportService.js
@@ -1,0 +1,7 @@
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000/api";
+
+export const getEventsByPopularity = async () => {
+    const response = await fetch(`${API_URL}/reportes/rank`);
+    if (!response.ok) throw new Error("Failed to fetch events by popularity");
+    return response.json();
+}


### PR DESCRIPTION
Introduce src/features/EventsAdmin/services/reportService.js exporting getEventsByPopularity which fetches the events popularity ranking from /reportes/rank. Uses VITE_API_URL (with a localhost fallback) and throws on non-OK responses before returning parsed JSON to be consumed by the EventsAdmin UI.