### PR TITLE
61-feat-create-the-service-to-show-the-top-3-events-most-solded

### DIFF
--- a/src/features/EventsAdmin/services/reportService.js
+++ b/src/features/EventsAdmin/services/reportService.js
@@ -5,3 +5,9 @@ export const getEventsByPopularity = async () => {
     if (!response.ok) throw new Error("Failed to fetch events by popularity");
     return response.json();
 }
+
+export const getTopMostSoldEvents = async () => {
+    const response = await fetch(`${API_URL}/reportes/top-most-sold-events`);
+    if (!response.ok) throw new Error ("Failed to fetch events by popularity");
+    return response.json();
+}


### PR DESCRIPTION
Introduce getTopMostSoldEvents() to fetch the /reportes/top-most-sold-events endpoint, throwing on non-OK responses and returning parsed JSON. This adds support for retrieving the top most sold events report from the API.

Issue #61 