### PR TITLE
144-feat-add-service-in-front-to-show-sold-vs-available-per-ticket-type-in-admin-event-detail

### DIFF
--- a/src/features/EventsAdmin/services/salesReportService.js
+++ b/src/features/EventsAdmin/services/salesReportService.js
@@ -31,3 +31,9 @@ export const getSalesReportByEvent = async (eventId) => {
 
   return result;
 };
+
+export const getEventAvailability = async (id) => {
+  const response = await fetch(`${API_URL}/evento-tipos-entrada/${id}/disponibilidad`);
+  if (!response.ok) throw new Error("Error fetching availability");
+  return await response.json();
+};


### PR DESCRIPTION
Introduce getEventAvailability(id) in salesReportService to fetch availability for an event-type from `${API_URL}/evento-tipos-entrada/:id/disponibilidad`. The function validates response.ok, throws an error on failure, and returns the parsed JSON payload.

Issue #144 