### PR TITLE
80-feat-create-purchase-api-service-for-active-events-only

### DIFF
--- a/src/features/EventsUsers/services/eventsUsers.js
+++ b/src/features/EventsUsers/services/eventsUsers.js
@@ -128,3 +128,20 @@ export const getTopSellingEvents = async () => {
     .sort((a, b) => b.totalVendido - a.totalVendido)
     .slice(0, 3);
 };
+
+export const purchaseTickets = async (purchaseData) => {
+    const response = await fetch(`${API_URL}/compras`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(purchaseData),
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || "Failed to process purchase");
+    }
+
+    return response.json();
+};


### PR DESCRIPTION
Add purchaseTickets to EventsUsers services to POST purchase data to the API (POST ${API_URL}/compras). The function sends JSON, parses the JSON response on success, and on non-OK responses attempts to parse an error message and throws an Error with a helpful message.

Issue #80 