### PR TITLE
Add PaymentCheckout and integrate payment flow

### DIFF
--- a/src/features/EventsUsers/components/PaymentCheckout.jsx
+++ b/src/features/EventsUsers/components/PaymentCheckout.jsx
@@ -1,0 +1,179 @@
+import React, { useState } from 'react';
+import { CreditCard, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
+import { usePurchase } from '../hooks/usePurchase'; // Asegúrate de ajustar la ruta
+
+export default function PaymentCheckout({ purchaseDetails, onPaymentSuccess }) {
+  const { executePurchase, loading } = usePurchase();
+  
+  // Estado local para los datos de la tarjeta
+  const [cardData, setCardData] = useState({
+    cardNumber: '',
+    cardBrand: 'visa', // Valor por defecto
+    cardHolder: '',
+    expiry: '',
+    cvc: ''
+  });
+
+  // Estado para manejar la respuesta visual del servicio
+  const [feedback, setFeedback] = useState({ type: null, message: '' });
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setCardData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setFeedback({ type: null, message: '' });
+
+    // 1. Construir el objeto de compra que espera tu API
+    // (Ajusta la estructura de 'pago' según lo que espere tu backend)
+    const payload = {
+      ...purchaseDetails, // Aquí deberían venir el usuario_id, evento_id, boletos, etc.
+      pago: {
+        tarjeta: cardData.cardNumber,
+        franquicia: cardData.cardBrand,
+        titular: cardData.cardHolder,
+        expiracion: cardData.expiry,
+        cvc: cardData.cvc
+      }
+    };
+
+    // 2. Ejecutar la compra usando tu hook
+    try {
+      const response = await executePurchase(payload);
+      
+      // Si el servicio responde correctamente
+      setFeedback({ 
+        type: 'success', 
+        message: response.mensaje || `¡Pago aprobado exitosamente! Orden #${response.id}` 
+      });
+      
+      // Llamar a una función externa si necesitas redirigir o cerrar un modal
+      if (onPaymentSuccess) {
+        setTimeout(() => onPaymentSuccess(response), 2000);
+      }
+      
+    } catch (error) {
+      // Si el servicio devuelve un error (fondos insuficientes, tarjeta rechazada, etc.)
+      setFeedback({ 
+        type: 'error', 
+        message: error.message || 'El pago fue rechazado. Por favor, verifica tus datos.' 
+      });
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto bg-white p-8 rounded-2xl shadow-lg border border-gray-100">
+      <div className="flex items-center mb-6">
+        <CreditCard className="text-blue-600 mr-3" size={28} />
+        <h2 className="text-2xl font-bold text-gray-800">Pago Seguro</h2>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        
+        {/* Selección de Franquicia */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">Franquicia</label>
+          <select
+            name="cardBrand"
+            value={cardData.cardBrand}
+            onChange={handleInputChange}
+            className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+            required
+          >
+            <option value="visa">Visa</option>
+            <option value="mastercard">Mastercard</option>
+            <option value="nu">Nu</option>
+          </select>
+        </div>
+
+        {/* Número de Tarjeta */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">Número de Tarjeta</label>
+          <input
+            type="text"
+            name="cardNumber"
+            placeholder="0000 0000 0000 0000"
+            value={cardData.cardNumber}
+            onChange={handleInputChange}
+            maxLength="19"
+            className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+            required
+          />
+        </div>
+
+        {/* Nombre, Fecha y CVC */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="col-span-2">
+            <label className="block text-sm font-semibold text-gray-700 mb-1">Titular de la Tarjeta</label>
+            <input
+              type="text"
+              name="cardHolder"
+              placeholder="Nombre como aparece en la tarjeta"
+              value={cardData.cardHolder}
+              onChange={handleInputChange}
+              className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">Expiración</label>
+            <input
+              type="text"
+              name="expiry"
+              placeholder="MM/YY"
+              value={cardData.expiry}
+              onChange={handleInputChange}
+              className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">CVC</label>
+            <input
+              type="password"
+              name="cvc"
+              placeholder="123"
+              value={cardData.cvc}
+              onChange={handleInputChange}
+              maxLength="4"
+              className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+              required
+            />
+          </div>
+        </div>
+
+        {/* Botón de Pago */}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full mt-4 bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-xl transition-colors shadow-sm flex items-center justify-center disabled:opacity-70 disabled:cursor-not-allowed"
+        >
+          {loading ? (
+            <>
+              <Loader2 className="animate-spin mr-2" size={20} />
+              Procesando...
+            </>
+          ) : (
+            'Confirmar Pago'
+          )}
+        </button>
+      </form>
+
+      {/* Mostrar la respuesta del servicio */}
+      {feedback.type && (
+        <div className={`mt-6 p-4 rounded-xl flex items-start ${
+          feedback.type === 'success' ? 'bg-green-50 border border-green-200 text-green-800' : 'bg-red-50 border border-red-200 text-red-800'
+        }`}>
+          {feedback.type === 'success' ? (
+            <CheckCircle className="mr-3 flex-shrink-0 mt-0.5" size={20} />
+          ) : (
+            <AlertCircle className="mr-3 flex-shrink-0 mt-0.5" size={20} />
+          )}
+          <p className="text-sm font-medium">{feedback.message}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/EventsUsers/components/PurchaseModal.jsx
+++ b/src/features/EventsUsers/components/PurchaseModal.jsx
@@ -126,11 +126,10 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
       evento_id: event.id,
       detallesCompra,
       pago: {
-        tarjeta: cardData.cardNumber,
         franquicia: cardData.cardBrand,
-        titular: cardData.cardHolder,
-        expiracion: cardData.expiry,
-        cvc: cardData.cvc
+        numero_tarjeta: cardData.cardNumber,
+        cvc: cardData.cvc,
+        fecha_expiracion: cardData.expiry
       }
     };
 

--- a/src/features/EventsUsers/components/PurchaseModal.jsx
+++ b/src/features/EventsUsers/components/PurchaseModal.jsx
@@ -1,20 +1,31 @@
 import React, { useState, useEffect } from "react";
-import { X, CheckCircle, AlertCircle, Ticket, Plus, Minus, Loader2 } from "lucide-react";
+import { X, CheckCircle, AlertCircle, Ticket, Plus, Minus, Loader2, CreditCard, ArrowLeft } from "lucide-react";
 import { usePurchase } from "../hooks/usePurchase";
-import ModalConfirmacion from "../../EventsAdmin/components/ModalConfirmation";
 
 const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
+  // VOLVEMOS a extraer solo executePurchase (eliminé processPurchaseWithValidation)
   const { loading, error, isSuccess, executePurchase, resetPurchase } = usePurchase();
 
   const [ticketQuantities, setTicketQuantities] = useState({});
   const [validationError, setValidationError] = useState(null);
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  
+  // Estados para manejar la vista de pago y los datos de la tarjeta
+  const [showPaymentForm, setShowPaymentForm] = useState(false);
+  const [cardData, setCardData] = useState({
+    cardNumber: '',
+    cardBrand: 'visa',
+    cardHolder: '',
+    expiry: '',
+    cvc: ''
+  });
 
   useEffect(() => {
     if (isOpen) {
       resetPurchase();
       setTicketQuantities({});
       setValidationError(null);
+      setShowPaymentForm(false); // Reiniciar vista
+      setCardData({ cardNumber: '', cardBrand: 'visa', cardHolder: '', expiry: '', cvc: '' }); // Reiniciar formulario
     }
   }, [isOpen, resetPurchase]);
 
@@ -62,16 +73,13 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
 
   const totalSelectedTickets = Object.values(ticketQuantities).reduce((sum, qty) => sum + qty, 0);
 
-  if (!isOpen || !event) return null;
-
-  // 3. FUNCIÓN PARA ACTUALIZAR CANTIDAD INDIVIDUAL
+  // FUNCIÓN PARA ACTUALIZAR CANTIDAD INDIVIDUAL
   const updateQuantity = (ticketId, delta, maxAvailable) => {
     setTicketQuantities((prev) => {
       const currentQty = prev[ticketId] || 0;
       const newQty = Math.max(0, Math.min(currentQty + delta, maxAvailable));
 
       const newState = { ...prev, [ticketId]: newQty };
-      // Limpiar keys con valor 0 para no enviar basura
       if (newQty === 0) {
         delete newState[ticketId];
       }
@@ -79,7 +87,10 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
     });
   };
 
-  if (!isOpen || !event) return null;
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setCardData(prev => ({ ...prev, [name]: value }));
+  };
 
   const handleInitiatePurchase = () => {
     setValidationError(null);
@@ -94,11 +105,12 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
       return;
     }
 
-    setShowConfirmModal(true);
+    // En lugar de abrir el modal de confirmación, pasamos al formulario de pago
+    setShowPaymentForm(true);
   };
 
-  const executeFinalPurchase = async () => {
-    setShowConfirmModal(false);
+  const executeFinalPurchase = async (e) => {
+    e.preventDefault();
 
     const detallesCompra = Object.entries(ticketQuantities).map(([ticketIdStr, cantidad]) => {
       const ticket = ticketTypes.find(t => String(t.id) === ticketIdStr);
@@ -108,13 +120,22 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
       };
     });
 
-    const payload = {
+    // UNIFICAMOS todo en un solo payload como acordamos
+    const payloadCompleto = {
       usuario_id: currentUser?.id,
       evento_id: event.id,
-      detallesCompra
+      detallesCompra,
+      pago: {
+        tarjeta: cardData.cardNumber,
+        franquicia: cardData.cardBrand,
+        titular: cardData.cardHolder,
+        expiracion: cardData.expiry,
+        cvc: cardData.cvc
+      }
     };
 
-    await executePurchase(payload);
+    // Llamamos a la función original del hook
+    await executePurchase(payloadCompleto);
   };
 
   const handleCloseAfterSuccess = () => {
@@ -122,16 +143,27 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
     window.location.reload();
   };
 
+  if (!isOpen || !event) return null;
+
   return (
-    <>
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm transition-opacity">
       <div className="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden relative">
 
         {/* HEADER */}
         <div className="bg-gray-50 px-6 py-4 border-b border-gray-100 flex justify-between items-center">
           <h2 className="text-lg font-bold text-gray-800 flex items-center">
-            <Ticket className="w-5 h-5 mr-2 text-blue-600" />
-            Buy Tickets
+            {showPaymentForm && !isSuccess ? (
+              <button 
+                onClick={() => setShowPaymentForm(false)}
+                className="mr-2 text-gray-500 hover:text-gray-800 transition-colors"
+                disabled={loading}
+              >
+                <ArrowLeft size={20} />
+              </button>
+            ) : (
+              <Ticket className="w-5 h-5 mr-2 text-blue-600" />
+            )}
+            {showPaymentForm && !isSuccess ? "Datos de Pago" : "Comprar Entradas"}
           </h2>
           <button
             onClick={onClose}
@@ -149,26 +181,132 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
           {isSuccess ? (
             <div className="flex flex-col items-center justify-center py-6 text-center">
               <CheckCircle className="w-16 h-16 text-green-500 mb-4" />
-              <h3 className="text-xl font-bold text-gray-900 mb-2">¡Purchase Successful!</h3>
+              <h3 className="text-xl font-bold text-gray-900 mb-2">¡Compra Exitosa!</h3>
               <p className="text-gray-600 mb-6">
-                Your tickets for <strong>{event.nombre}</strong> have been secured.
+                Tus entradas para <strong>{event.nombre}</strong> han sido aseguradas.
               </p>
               <button
                 onClick={handleCloseAfterSuccess}
                 className="w-full bg-blue-600 text-white font-semibold py-2 rounded-lg hover:bg-blue-700 transition-colors"
               >
-                Close Window
+                Cerrar Ventana
               </button>
             </div>
+          ) : showPaymentForm ? (
+            /* FORMULARIO DE PAGO (PASO 2) */
+            <form onSubmit={executeFinalPurchase} className="space-y-4">
+              {/* MENSAJE DE ERROR DEL API */}
+              {error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-lg flex items-start text-sm text-red-600 mb-4">
+                  <AlertCircle className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <div className="flex justify-between items-center bg-blue-50 p-3 rounded-lg border border-blue-100 mb-4">
+                <span className="text-sm text-blue-800 font-medium">Total a pagar:</span>
+                <span className="text-lg font-bold text-blue-900">${totalPrice.toLocaleString("es-CO")}</span>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Franquicia</label>
+                <select
+                  name="cardBrand"
+                  value={cardData.cardBrand}
+                  onChange={handleInputChange}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
+                  required
+                >
+                  <option value="visa">Visa</option>
+                  <option value="mastercard">Mastercard</option>
+                  <option value="nu">Nu</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Número de Tarjeta</label>
+                <div className="relative">
+                  <CreditCard className="absolute left-3 top-2.5 text-gray-400" size={18} />
+                  <input
+                    type="text"
+                    name="cardNumber"
+                    placeholder="0000 0000 0000 0000"
+                    value={cardData.cardNumber}
+                    onChange={handleInputChange}
+                    maxLength="19"
+                    className="w-full pl-10 border border-gray-300 rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Titular de la Tarjeta</label>
+                <input
+                  type="text"
+                  name="cardHolder"
+                  placeholder="Nombre en la tarjeta"
+                  value={cardData.cardHolder}
+                  onChange={handleInputChange}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
+                  required
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Expiración</label>
+                  <input
+                    type="text"
+                    name="expiry"
+                    placeholder="MM/AA"
+                    value={cardData.expiry}
+                    onChange={handleInputChange}
+                    maxLength="5"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">CVC</label>
+                  <input
+                    type="password"
+                    name="cvc"
+                    placeholder="123"
+                    value={cardData.cvc}
+                    onChange={handleInputChange}
+                    maxLength="4"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className="pt-4 mt-2 border-t border-gray-200">
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center shadow-sm"
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                      Procesando Pago...
+                    </>
+                  ) : (
+                    `Pagar $${totalPrice.toLocaleString("es-CO")}`
+                  )}
+                </button>
+              </div>
+            </form>
           ) : (
-            /* FORMULARIO DE COMPRA */
+            /* SELECCIÓN DE ENTRADAS (PASO 1) */
             <>
               <div className="mb-6">
                 <h3 className="font-semibold text-gray-900 text-lg">{event.nombre}</h3>
                 <p className="text-sm text-gray-500">{event.fecha} • {event.lugar}</p>
               </div>
 
-              {/* MENSAJE DE ERROR */}
               {(error || validationError) && (
                 <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start text-sm text-red-600">
                   <AlertCircle className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5" />
@@ -176,9 +314,8 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
                 </div>
               )}
 
-              {/* SELECCIÓN DE ENTRADA */}
               <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">Select Tickets</label>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Selecciona tus entradas</label>
                 <div className="space-y-3">
                   {ticketTypes.map((ticket) => {
                     const isSoldOut = Number(ticket.disponibles) <= 0;
@@ -196,7 +333,7 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
                         <div className="flex items-center justify-between mb-3">
                           <div className="flex flex-col">
                             <span className="font-medium text-gray-900">
-                              {ticket.nombre || "General Entry"}
+                              {ticket.nombre || "Entrada General"}
                             </span>
                             <span className="text-sm text-gray-500">
                               ${ticket.precio.toLocaleString("es-CO")}
@@ -210,12 +347,12 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
                               {ticket.disponibles} disp.
                             </span>
                           ) : (
-                            <span className="text-xs text-red-500 font-bold uppercase">Sold Out</span>
+                            <span className="text-xs text-red-500 font-bold uppercase">Agotado</span>
                           )}
                         </div>
 
                         <div className="flex items-center justify-between pt-3 border-t border-gray-100">
-                          <span className="text-sm font-medium text-gray-700">Quantity</span>
+                          <span className="text-sm font-medium text-gray-700">Cantidad</span>
                           <div className="flex items-center bg-white border border-gray-300 rounded-lg overflow-hidden">
                             <button
                               type="button"
@@ -242,15 +379,15 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
                     );
                   })}
                   {ticketTypes.length === 0 && (
-                    <p className="text-sm text-gray-500 italic">No tickets configured for this event.</p>
+                    <p className="text-sm text-gray-500 italic">No hay entradas configuradas para este evento.</p>
                   )}
                 </div>
               </div>
 
-              {/* TOTAL Y BOTÓN DE PAGO */}
+              {/* TOTAL Y BOTÓN PARA IR A PAGAR */}
               <div className="pt-4 border-t border-gray-200 flex items-center justify-between sticky bottom-0 bg-white">
                 <div>
-                  <span className="block text-sm text-gray-500">Total Price</span>
+                  <span className="block text-sm text-gray-500">Total</span>
                   <span className="block text-2xl font-bold text-gray-900">
                     ${totalPrice.toLocaleString("es-CO")}
                   </span>
@@ -260,14 +397,7 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
                   disabled={totalSelectedTickets === 0 || loading || ticketTypes.length === 0}
                   className="bg-blue-600 text-white font-semibold px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center shadow-sm"
                 >
-                  {loading ? (
-                    <>
-                      <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                      Processing...
-                    </>
-                  ) : (
-                    "Confirm Purchase"
-                  )}
+                  Continuar al Pago
                 </button>
               </div>
             </>
@@ -276,17 +406,6 @@ const PurchaseModal = ({ isOpen, onClose, event, currentUser }) => {
         </div>
       </div>
     </div>
-
-    {/* RENDERIZADO DEL MODAL DE CONFIRMACIÓN */}
-    <ModalConfirmacion
-      isOpen={showConfirmModal}
-      titulo="Confirmar Compra"
-      mensaje={`¿Estás seguro que deseas comprar ${totalSelectedTickets} entrada(s) por un total de $${totalPrice.toLocaleString("es-CO")}?`}
-      onConfirm={executeFinalPurchase}
-      onCancel={() => setShowConfirmModal(false)}
-      isDanger={false}
-    />
-    </>
   );
 };
 

--- a/src/features/EventsUsers/hooks/usePurchase.js
+++ b/src/features/EventsUsers/hooks/usePurchase.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { purchaseTickets, getPurchaseHistory, getPurchaseDetails } from "../services/eventsUsers";
+import { purchaseTickets, getPurchaseHistory, getPurchaseDetails, validatePaymentInfo } from "../services/eventsUsers";
 
 export const usePurchase = () => {
     const [loading, setLoading] = useState(false);
@@ -90,11 +90,26 @@ export const usePurchase = () => {
         }
     }, []);
 
+    const processPurchaseWithValidation = async (purchasePayload, cardData) => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            await validatePaymentInfo(cardData);
+            await executePurchase(purchasePayload);
+
+        } catch (err) {
+            setError(err.message || "Ocurrió un error al procesar el pago.");
+            setLoading(false); 
+        }
+    };
+
     return {
         loading,
         error,
         isSuccess,
         executePurchase,
+        processPurchaseWithValidation,
         resetPurchase,
         purchases,
         loadingPurchases,

--- a/src/features/EventsUsers/services/eventsUsers.js
+++ b/src/features/EventsUsers/services/eventsUsers.js
@@ -176,3 +176,20 @@ export const getPurchaseDetails = async (compra_id) => {
 
   return response.json();
 };
+
+export const validatePaymentInfo = async (cardData) => {
+  const response = await fetch('/api/validar-tarjeta', { 
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(cardData),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.mensaje || errorData.error || "La tarjeta fue rechazada o es inválida.");
+  }
+
+  return await response.json();
+};

--- a/src/features/EventsUsers/services/eventsUsers.js
+++ b/src/features/EventsUsers/services/eventsUsers.js
@@ -135,24 +135,24 @@ export const getTopSellingEvents = async () => {
 };
 
 export const purchaseTickets = async (purchaseData) => {
-    const response = await fetch(`${API_URL}/compras`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(purchaseData),
+  try {
+    const response = await fetch('/api/compras', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(purchaseData)
     });
 
     if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      errorData.error ||
-      errorData.message ||
-      "Failed to process purchase"
-    );
+      const errorData = await response.json();
+      throw new Error(errorData.message || "Error al procesar el pago"); 
     }
-
-    return response.json();
+    return await response.json();
+    
+  } catch (error) {
+    throw new Error(error.message || "Error de conexión con el servidor");
+  }
 };
 
 export const getPurchaseHistory = async (usuario_id) => {

--- a/src/features/EventsUsers/services/eventsUsers.js
+++ b/src/features/EventsUsers/services/eventsUsers.js
@@ -135,18 +135,19 @@ export const getTopSellingEvents = async () => {
 };
 
 export const purchaseTickets = async (payloadCompleto) => {
-  const response = await fetch('/api/compras', {
+  const response = await fetch(`${API_URL}/compras`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payloadCompleto)
   });
 
   if (!response.ok) {
-    // 1. Convertimos la respuesta del mapearErrorDominio a JSON
-    const errorData = await response.json();
-    
-    // 2. Extraemos la propiedad "message" que manda tu backend
-    throw new Error(errorData.message || "Error al procesar el pago");
+    const errorData = await safeJson(response);
+    throw new Error(
+      errorData?.message ||
+      errorData?.error ||
+      "Error al procesar el pago"
+    );
   }
 
   return await response.json();
@@ -174,7 +175,7 @@ export const getPurchaseDetails = async (compra_id) => {
 };
 
 export const validatePaymentInfo = async (cardData) => {
-  const response = await fetch('/api/validar-tarjeta', { 
+  const response = await fetch(`${API_URL}/validar-tarjeta`, { 
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/features/EventsUsers/services/eventsUsers.js
+++ b/src/features/EventsUsers/services/eventsUsers.js
@@ -134,27 +134,23 @@ export const getTopSellingEvents = async () => {
   return Array.isArray(data) ? data.slice(0, 3) : [];
 };
 
-export const purchaseTickets = async (purchaseData) => {
-  try {
-    const response = await fetch('/api/compras', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(purchaseData)
-    });
+export const purchaseTickets = async (payloadCompleto) => {
+  const response = await fetch('/api/compras', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payloadCompleto)
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.message || "Error al procesar el pago"); 
-    }
-    return await response.json();
+  if (!response.ok) {
+    // 1. Convertimos la respuesta del mapearErrorDominio a JSON
+    const errorData = await response.json();
     
-  } catch (error) {
-    throw new Error(error.message || "Error de conexión con el servidor");
+    // 2. Extraemos la propiedad "message" que manda tu backend
+    throw new Error(errorData.message || "Error al procesar el pago");
   }
-};
 
+  return await response.json();
+};
 export const getPurchaseHistory = async (usuario_id) => {
   const response = await fetch(`${API_URL}/compras/usuario/${usuario_id}/historial`);
 


### PR DESCRIPTION
Introduce a new PaymentCheckout component to collect card details and call the purchase hook. Update PurchaseModal to add an in-modal payment step, card data state/inputs, back navigation, and localized UI text; remove the separate confirmation modal and instead build a unified payload that includes 'pago' (card info) before calling executePurchase. Also reset payment state on open, show API errors and success states, and add minor UI/icon tweaks and copy changes. #220 